### PR TITLE
feat: added VirtualMachineTool

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
+    "@azure/arm-compute": "^22.4.0",
     "@azure/identity": "^4.8.0",
     "@azure/storage-blob": "^12.27.0",
     "mcp-framework": "^0.2.11"

--- a/src/tools/VirtualMachine/BaseAzureVirtualMachineTool.ts
+++ b/src/tools/VirtualMachine/BaseAzureVirtualMachineTool.ts
@@ -1,0 +1,28 @@
+import { MCPTool } from 'mcp-framework';
+import { ComputeManagementClient } from '@azure/arm-compute';
+import { DefaultAzureCredential } from '@azure/identity';
+
+export interface BaseVirtualMachineInput {
+    subscriptionId: string;
+    resourceGroupName?: string;
+    vmName?: string;
+}
+
+export abstract class BaseAzureVirtualMachineTool<T extends BaseVirtualMachineInput> extends MCPTool<T> {
+    protected async getClient(subscriptionId: string): Promise<ComputeManagementClient> {
+        const credential = new DefaultAzureCredential();
+        return new ComputeManagementClient(credential, subscriptionId);
+    }
+
+    protected validateResourceGroup(resourceGroupName?: string): void {
+        if (!resourceGroupName) {
+            throw new Error('Resource Group name is required for this operation.');
+        }
+    }
+
+    protected validateVmName(vmName?: string): void {
+        if (!vmName) {
+            throw new Error('Virtual Machine name is required for this operation.');
+        }
+    }
+}

--- a/src/tools/VirtualMachine/DeleteVirtualMachineTool.ts
+++ b/src/tools/VirtualMachine/DeleteVirtualMachineTool.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { BaseAzureVirtualMachineTool, BaseVirtualMachineInput } from './BaseAzureVirtualMachineTool';
+
+type DeleteVMInput = Required<BaseVirtualMachineInput>;
+
+class DeleteVirtualMachineTool extends BaseAzureVirtualMachineTool<DeleteVMInput> {
+    name = 'azure_vms_delete';
+    description = 'Delete an Azure Virtual Machine';
+
+    schema = {
+        subscriptionId: {
+            type: z.string(),
+            description: 'Azure Subscription ID'
+        },
+        resourceGroupName: {
+            type: z.string(),
+            description: 'Azure Resource Group name'
+        },
+        vmName: {
+            type: z.string(),
+            description: 'Virtual Machine name'
+        }
+    };
+
+    async execute(input: DeleteVMInput) {
+        this.validateResourceGroup(input.resourceGroupName);
+        this.validateVmName(input.vmName);
+
+        const client = await this.getClient(input.subscriptionId);
+        await client.virtualMachines.beginDeleteAndWait(input.resourceGroupName, input.vmName);
+        return { status: 'deleted', vmName: input.vmName };
+    }
+}
+
+export default DeleteVirtualMachineTool;

--- a/src/tools/VirtualMachine/ListVirtualMachinesTool.ts
+++ b/src/tools/VirtualMachine/ListVirtualMachinesTool.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { BaseAzureVirtualMachineTool, BaseVirtualMachineInput } from './BaseAzureVirtualMachineTool';
+
+type ListVMsInput = BaseVirtualMachineInput;
+
+class ListVirtualMachinesTool extends BaseAzureVirtualMachineTool<ListVMsInput> {
+    name = 'azure_vms_list';
+    description = 'List all Azure Virtual Machines';
+
+    schema = {
+        subscriptionId: {
+            type: z.string(),
+            description: 'Azure Subscription ID'
+        }
+    };
+
+    async execute(input: ListVMsInput) {
+        const client = await this.getClient(input.subscriptionId);
+        const vmList = await client.virtualMachines.listAll();
+        const allVMs = [];
+        for await (const vm of vmList) {
+            allVMs.push({
+                name: vm.name,
+                id: vm.id
+            });
+        }
+        return allVMs;
+    }
+}
+
+export default ListVirtualMachinesTool;

--- a/src/tools/VirtualMachine/RestartVirtualMachineTool.ts
+++ b/src/tools/VirtualMachine/RestartVirtualMachineTool.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { BaseAzureVirtualMachineTool, BaseVirtualMachineInput } from './BaseAzureVirtualMachineTool';
+
+type RestartVMInput = Required<BaseVirtualMachineInput>;
+
+class RestartVirtualMachineTool extends BaseAzureVirtualMachineTool<RestartVMInput> {
+    name = 'azure_vms_restart';
+    description = 'Restart an Azure Virtual Machine';
+
+    schema = {
+        subscriptionId: {
+            type: z.string(),
+            description: 'Azure Subscription ID'
+        },
+        resourceGroupName: {
+            type: z.string(),
+            description: 'Azure Resource Group name'
+        },
+        vmName: {
+            type: z.string(),
+            description: 'Virtual Machine name'
+        }
+    };
+
+    async execute(input: RestartVMInput) {
+        this.validateResourceGroup(input.resourceGroupName);
+        this.validateVmName(input.vmName);
+
+        const client = await this.getClient(input.subscriptionId);
+        await client.virtualMachines.beginRestartAndWait(input.resourceGroupName, input.vmName);
+        return { status: 'restarted', vmName: input.vmName };
+    }
+}
+
+export default RestartVirtualMachineTool;

--- a/src/tools/VirtualMachine/StartVirtualMachineTool.ts
+++ b/src/tools/VirtualMachine/StartVirtualMachineTool.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { BaseAzureVirtualMachineTool, BaseVirtualMachineInput } from './BaseAzureVirtualMachineTool';
+
+type StartVMInput = Required<BaseVirtualMachineInput>;
+
+class StartVirtualMachineTool extends BaseAzureVirtualMachineTool<StartVMInput> {
+    name = 'azure_vms_start';
+    description = 'Start an Azure Virtual Machine';
+
+    schema = {
+        subscriptionId: {
+            type: z.string(),
+            description: 'Azure Subscription ID'
+        },
+        resourceGroupName: {
+            type: z.string(),
+            description: 'Azure Resource Group name'
+        },
+        vmName: {
+            type: z.string(),
+            description: 'Virtual Machine name'
+        }
+    };
+
+    async execute(input: StartVMInput) {
+        this.validateResourceGroup(input.resourceGroupName);
+        this.validateVmName(input.vmName);
+
+        const client = await this.getClient(input.subscriptionId);
+        await client.virtualMachines.beginStartAndWait(input.resourceGroupName, input.vmName);
+        return { status: 'started', vmName: input.vmName };
+    }
+}
+
+export default StartVirtualMachineTool;

--- a/src/tools/VirtualMachine/StopVirtualMachineTool.ts
+++ b/src/tools/VirtualMachine/StopVirtualMachineTool.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+import { BaseAzureVirtualMachineTool, BaseVirtualMachineInput } from './BaseAzureVirtualMachineTool';
+
+type StopVMInput = Required<BaseVirtualMachineInput>;
+
+class StopVirtualMachineTool extends BaseAzureVirtualMachineTool<StopVMInput> {
+    name = 'azure_vms_stop';
+    description = 'Stop an Azure Virtual Machine';
+
+    schema = {
+        subscriptionId: {
+            type: z.string(),
+            description: 'Azure Subscription ID'
+        },
+        resourceGroupName: {
+            type: z.string(),
+            description: 'Azure Resource Group name'
+        },
+        vmName: {
+            type: z.string(),
+            description: 'Virtual Machine name'
+        }
+    };
+
+    async execute(input: StopVMInput) {
+        this.validateResourceGroup(input.resourceGroupName);
+        this.validateVmName(input.vmName);
+
+        const client = await this.getClient(input.subscriptionId);
+        await client.virtualMachines.beginPowerOffAndWait(input.resourceGroupName, input.vmName);
+        return { status: 'stopped', vmName: input.vmName };
+    }
+}
+
+export default StopVirtualMachineTool;


### PR DESCRIPTION
Added VIrtual Machine that has the following tools supported:

- azure_vms_list (list all vms in an azure subscription)
- azure_vms_delete (delete a given Azure VM)
- azure_vms_restart (restarts a given Azure VM)
- azure_vms_start (starts a given Azure VM)
- azure_vms_stop (stops a given Azure VM)

Example usage of listing vm's then starting one:

![image](https://github.com/user-attachments/assets/e75cdc8c-0bff-4b0e-942d-6fe5d1054c34)
